### PR TITLE
Customization required by OF

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,20 @@
 
 Gitleaks Action provides a simple way to run gitleaks in your CI/CD pipeline.
 
+Attention: this project is a fork of the original project [zricethezav/gitleaks-action](https://github.com/zricethezav/gitleaks-action).
+For everything that is not discussed in this document see the official documentation [here](https://github.com/zricethezav/gitleaks-action/blob/master/README.md).
 
-### Sample Workflow
+### OF Customizations
+- The `exitcode` action's output (i.e. `steps.<gitleaks_action_id>.outputs.exitcode`) returns `0` or `1` according to the result of the test.
+- The Action's input called `config-path`, used to replace the Gitleaks config using the `--config-path` parameter, is now used for passing additional configurations by using the `--additional-config` instead.
+- On every Github `push` event the action creates a report file called `gitleaks-output.json` on the root of the project.
+
+
+### Adding custom .gitleaks.toml configuration
+
+This action assumes by default the use of all Gitleaks rules and can be customized using the `config-path` argument.
+The rules provided will be merged with the existing default rules and not, as in the original action, been replaced.
+
 ```
 name: gitleaks
 
@@ -17,38 +29,11 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: gitleaks-action
-      uses: zricethezav/gitleaks-action@master
-```
-
-### Using your own .gitleaks.toml configuration
-```
-name: gitleaks
-
-on: [push,pull_request]
-
-jobs:
-  gitleaks:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - name: gitleaks-action
-      uses: zricethezav/gitleaks-action@master
+      uses: motain/gitleaks-action@master
       with:
-        config-path: security/.gitleaks.toml
+        config-path: .of/security/gitleaks.toml
 ```
     > The `config-path` is relative to your GitHub Worskpace
 
-### NOTE!!!
-You must use `actions/checkout` before the gitleaks-action step. If you are using `actions/checkout@v2` you must specify a commit depth other than the default which is 1. 
-
-ex: 
-```
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: '0'
-    - name: gitleaks-action
-      uses: zricethezav/gitleaks-action@master
-```
-
-using a fetch-depth of '0' clones the entire history. If you want to do a more efficient clone, use '2', but that is not guaranteed to work with pull requests.   
+### TODOs
+- Perhaps, instead of hardcoding these changes on a forked repository, we should parametrize the changes as action inputs and open a PR on the official project.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,7 +25,7 @@ if [ $? -eq 1 ]
 then
   GITLEAKS_RESULT=$(echo -e "\e[31m🛑 STOP! Gitleaks encountered leaks")
   echo "$GITLEAKS_RESULT"
-  echo "::set-output name=exitcode::$GITLEAKS_RESULT"
+  echo "::set-output name=exitcode::1"
   echo "----------------------------------"
   echo "$CAPTURE_OUTPUT"
   echo "::set-output name=result::$CAPTURE_OUTPUT"
@@ -34,6 +34,6 @@ then
 else
   GITLEAKS_RESULT=$(echo -e "\e[32m✅ SUCCESS! Your code is good to go!")
   echo "$GITLEAKS_RESULT"
-  echo "::set-output name=exitcode::$GITLEAKS_RESULT"
+  echo "::set-output name=exitcode::0"
   echo "------------------------------------"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,8 +10,6 @@ fi
 
 echo running gitleaks "$(gitleaks --version) with the following command👇"
 
-DONATE_MSG="👋 maintaining gitleaks takes a lot of work so consider sponsoring me or donating a little something\n\e[36mhttps://github.com/sponsors/zricethezav\n\e[36mhttps://www.paypal.me/zricethezav\n"
-
 if [ "$GITHUB_EVENT_NAME" = "push" ]
 then
   echo gitleaks --path=$GITHUB_WORKSPACE --verbose --redact $CONFIG
@@ -32,12 +30,10 @@ then
   echo "$CAPTURE_OUTPUT"
   echo "::set-output name=result::$CAPTURE_OUTPUT"
   echo "----------------------------------"
-  echo -e $DONATE_MSG
   exit 1
 else
   GITLEAKS_RESULT=$(echo -e "\e[32m✅ SUCCESS! Your code is good to go!")
   echo "$GITLEAKS_RESULT"
   echo "::set-output name=exitcode::$GITLEAKS_RESULT"
   echo "------------------------------------"
-  echo -e $DONATE_MSG
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,8 +12,8 @@ echo running gitleaks "$(gitleaks --version) with the following command👇"
 
 if [ "$GITHUB_EVENT_NAME" = "push" ]
 then
-  echo gitleaks --path=$GITHUB_WORKSPACE --verbose --redact $CONFIG
-  CAPTURE_OUTPUT=$(gitleaks --path=$GITHUB_WORKSPACE --verbose --redact $CONFIG)
+  echo gitleaks --path=$GITHUB_WORKSPACE --verbose --report=gitleaks-output.json --redact $CONFIG
+  CAPTURE_OUTPUT=$(gitleaks --path=$GITHUB_WORKSPACE --verbose --report=gitleaks-output.json --redact $CONFIG)
 elif [ "$GITHUB_EVENT_NAME" = "pull_request" ]
 then 
   git --git-dir="$GITHUB_WORKSPACE/.git" log --left-right --cherry-pick --pretty=format:"%H" remotes/origin/$GITHUB_BASE_REF... > commit_list.txt

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@ CONFIG=""
 
 # check if a custom config have been provided
 if [ -f "$GITHUB_WORKSPACE/$INPUT_CONFIG_PATH" ]; then
-  CONFIG=" --config-path=$GITHUB_WORKSPACE/$INPUT_CONFIG_PATH"
+  CONFIG=" --additional-config=$GITHUB_WORKSPACE/$INPUT_CONFIG_PATH"
 fi
 
 echo running gitleaks "$(gitleaks --version) with the following command👇"


### PR DESCRIPTION
In the context of [CORE-1663](https://onefootball.atlassian.net/browse/CORE-1663) we need some changes to the public Gitleaks Github Action.

We will need hosting and pointing the OF Gitleaks Github Workflow to this customization until the official [zricethezav/gitleaks-action](https://github.com/zricethezav/gitleaks-action) will support the _same_ features.

This Github Action version is already been tagged as `v1.6.0-of-custom` and can be then used as in the following example:
```
    - uses: actions/checkout@v1
    - name: gitleaks-action
      uses: motain/gitleaks-action@v1.6.0-of-custom
      with:
        config-path: ".of/security/gitleaks.toml"
```
