### PR TITLE
chore(forked-action): No need to check for `push`

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,6 +1,6 @@
 name: gitleaks
 
-on: [push, pull_request, workflow_dispatch]
+on: [pull_request, workflow_dispatch]
 
 jobs:
   gitleaks:


### PR DESCRIPTION
Checking for pushes will check the entire git history and there is no
point for us to check these, being a forked repository and being just
users of this action.
