### PR TITLE
fix(permission): commit_list.txt moved to /tmp/

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,9 +12,9 @@ echo running gitleaks "$(gitleaks --version) with the following command👇"
 
 if [ "$GITHUB_EVENT_NAME" = "pull_request" ]
 then 
-  git --git-dir="$GITHUB_WORKSPACE/.git" log --left-right --cherry-pick --pretty=format:"%H" remotes/origin/$GITHUB_BASE_REF... > commit_list.txt
-  echo gitleaks --path=$GITHUB_WORKSPACE --verbose --redact --commits-file=commit_list.txt $CONFIG
-  CAPTURE_OUTPUT=$(gitleaks --path=$GITHUB_WORKSPACE --verbose --redact --commits-file=commit_list.txt $CONFIG)
+  git --git-dir="$GITHUB_WORKSPACE/.git" log --left-right --cherry-pick --pretty=format:"%H" remotes/origin/$GITHUB_BASE_REF... > /tmp/commit_list.txt
+  echo gitleaks --path=$GITHUB_WORKSPACE --verbose --redact --commits-file=/tmp/commit_list.txt $CONFIG
+  CAPTURE_OUTPUT=$(gitleaks --path=$GITHUB_WORKSPACE --verbose --redact --commits-file=/tmp/commit_list.txt $CONFIG)
 else
   echo gitleaks --path=$GITHUB_WORKSPACE --verbose --report=gitleaks-output.json --redact $CONFIG
   CAPTURE_OUTPUT=$(gitleaks --path=$GITHUB_WORKSPACE --verbose --report=gitleaks-output.json --redact $CONFIG)


### PR DESCRIPTION
With the changes introduced by #3 the user that run the gitleaks command
is not root anymore (see [here](https://github.com/zricethezav/gitleaks/blob/v7.6.1/Dockerfile#L11)):
This commit fixes the permission problem tha occurs when the actions
tries to write inside the root of the container.
