### PR TITLE
fix(permissios): Once and for all makes new version working

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,5 @@ LABEL "repository"="https://github.com/zricethezav/gitleaks-action"
 
 ADD entrypoint.sh /entrypoint.sh
 ADD gitleaks.toml /gitleaks.toml
+USER root
 ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,9 +12,9 @@ echo running gitleaks "$(gitleaks --version) with the following command👇"
 
 if [ "$GITHUB_EVENT_NAME" = "pull_request" ]
 then 
-  git --git-dir="$GITHUB_WORKSPACE/.git" log --left-right --cherry-pick --pretty=format:"%H" remotes/origin/$GITHUB_BASE_REF... > /tmp/commit_list.txt
-  echo gitleaks --path=$GITHUB_WORKSPACE --verbose --redact --commits-file=/tmp/commit_list.txt $CONFIG
-  CAPTURE_OUTPUT=$(gitleaks --path=$GITHUB_WORKSPACE --verbose --redact --commits-file=/tmp/commit_list.txt $CONFIG)
+  git --git-dir="$GITHUB_WORKSPACE/.git" log --left-right --cherry-pick --pretty=format:"%H" remotes/origin/$GITHUB_BASE_REF... > commit_list.txt
+  echo gitleaks --path=$GITHUB_WORKSPACE --verbose --redact --commits-file=commit_list.txt $CONFIG
+  CAPTURE_OUTPUT=$(gitleaks --path=$GITHUB_WORKSPACE --verbose --redact --commits-file=commit_list.txt $CONFIG)
 else
   echo gitleaks --path=$GITHUB_WORKSPACE --verbose --report=gitleaks-output.json --redact $CONFIG
   CAPTURE_OUTPUT=$(gitleaks --path=$GITHUB_WORKSPACE --verbose --report=gitleaks-output.json --redact $CONFIG)


### PR DESCRIPTION
Revert 69210242c702bdaa1f53f22287f859a12aaacbc9 and use `root` as
container user. The reason for this ugly change is that all Github
Workflows (one for each OF repository) are coupled with this
requirement: they expect a to find a `gitleaks-output.json` file in the
root folder of the container (i.e.
    [here](https://github.com/motain/android-iLiga-Libraries/actions/runs/1819251186/workflow#L4))

This comes again under the umbrella of technical debts.
