### PR TITLE
fix: Temporary disable rule

### DIFF
--- a/gitleaks.toml
+++ b/gitleaks.toml
@@ -532,12 +532,12 @@ description = "Typeform API token"
 regex = '''(?i)(typeform[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}(tfp_[a-z0-9\-_\.=]{59})'''
 secretGroup = 3
 
-[[rules]]
-id = "generic-api-key"
-description = "Generic API Key"
-regex = '''(?i)((key|api|token|secret|password)[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([0-9a-zA-Z\-_=]{8,64})['\"]'''
-entropy = 3.7
-secretGroup = 4
+#[[rules]]
+#id = "generic-api-key"
+#description = "Generic API Key"
+#regex = '''(?i)((key|api|token|secret|password)[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([0-9a-zA-Z\-_=]{8,64})['\"]'''
+#entropy = 3.7
+#secretGroup = 4
 
 
 [allowlist]


### PR DESCRIPTION
A bit in a rush, but we need to disable this rule for now because is
causing about 16K false positives and teams are being blocked by this.
