### PR TITLE
fix: Failures due to bug in `v7.6.1` => Downgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM zricethezav/gitleaks:v7.6.1
+FROM zricethezav/gitleaks:v7.5.0
 
 LABEL "com.github.actions.name"="gitleaks-action"
 LABEL "com.github.actions.description"="runs gitleaks on push and pull request events"


### PR DESCRIPTION
While we look for a fix to this same bug and then jump to `v8`, this
commit temporary downgrade Gitleaks action version as suggested by the
author.

Refs:
- https://github.com/zricethezav/gitleaks/issues/630
